### PR TITLE
fix(build): Exclude Docusaurus from main TS build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,58 @@
+name: Deploy Documentation to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # Or your project's default branch
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy-docusaurus:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm' # Assuming npm, change to 'yarn' if yarn.lock is in docs/website
+          cache-dependency-path: docs/website/package-lock.json # Or yarn.lock
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install Docusaurus dependencies
+        working-directory: ./docs/website
+        run: npm ci # Using npm ci for cleaner installs in CI
+
+      - name: Build Docusaurus site
+        working-directory: ./docs/website
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload the build output from Docusaurus
+          path: ./docs/website/build
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -3,3 +3,31 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## 📄 Documentation
+
+This project now includes a comprehensive documentation site built with Docusaurus, located in the `docs/website` directory. It contains:
+
+*   **Product Information**: Overview of Aran API Sentinel and its capabilities.
+*   **Feature Guides**: Detailed explanations of core features.
+*   **Technical Documentation**: Initial setup guides and workflow diagrams.
+
+**To view the documentation locally:**
+
+1.  Navigate to the `docs/website` directory:
+    ```bash
+    cd docs/website
+    ```
+2.  Install dependencies (if you haven't already):
+    ```bash
+    npm install
+    ```
+    (or `yarn install` if you prefer Yarn)
+3.  Start the Docusaurus development server:
+    ```bash
+    npm run start
+    ```
+    (or `yarn start`)
+4.  Open `http://localhost:3000` (or the port indicated by Docusaurus, usually 3000) in your browser.
+
+(Once the documentation site is deployed, for example via GitHub Pages, the live URL will be added here.)

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -191,7 +191,7 @@ export default function DashboardPage() {
               <Line yAxisId="left" type="monotone" dataKey="latency" strokeWidth={2.5} dot={{r:4, fill:'hsl(var(--background))', stroke:'hsl(var(--chart-1))'}} activeDot={{r:6}} stroke="hsl(var(--chart-1))" name={chartConfig.latency.label} />
               <Line yAxisId="center" type="monotone" dataKey="errorRate" strokeWidth={2.5} dot={{r:4, fill:'hsl(var(--background))', stroke:'hsl(var(--chart-5))'}} activeDot={{r:6}} stroke="hsl(var(--chart-5))" name={chartConfig.errorRate.label} />
               {/* <Line yAxisId="right" type="monotone" dataKey="rps" strokeWidth={2} dot={{r:4, fill:'hsl(var(--background))', stroke:'hsl(var(--chart-3))'}} activeDot={{r:6}} stroke="hsl(var(--chart-3))" name={chartConfig.rps.label} /> */}
-              <ChartLegend content={<ChartLegendContent wrapperStyle={{paddingTop: '16px'}} />} />
+              <ChartLegend content={<ChartLegendContent style={{paddingTop: '16px'}} />} />
             </LineChart>
           </ChartContainer>
         </GlassCard>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "docs/website"]
 }


### PR DESCRIPTION
Modifies the root `tsconfig.json` to add `docs/website` to the `exclude` array. This prevents the main Next.js TypeScript build process from attempting to compile files within the Docusaurus project, which was causing type errors related to Docusaurus-specific module aliases like `@theme/Layout`.

This change is intended to allow the main Next.js application to build without interference from the separate Docusaurus application located in `docs/website`.