### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/app/(app)/api-catalog/page.tsx
+++ b/src/app/(app)/api-catalog/page.tsx
@@ -1,6 +1,15 @@
 
 "use client";
 
+function sanitizeUrl(url: string): string {
+  try {
+    const parsedUrl = new URL(url, window.location.origin);
+    return parsedUrl.href;
+  } catch {
+    return ""; // Return an empty string for invalid URLs
+  }
+}
+
 import * as React from "react";
 import {
   Table,
@@ -104,7 +113,7 @@ export default function ApiCatalogPage() {
         category: newApiCategory,
         owner: newApiOwner,
         status: "development",
-        documentationUrl: newApiDocsUrl
+        documentationUrl: sanitizeUrl(newApiDocsUrl)
     };
     setApis([...apis, newApi]);
     setIsDialogOpen(false);
@@ -209,7 +218,7 @@ export default function ApiCatalogPage() {
                   </TableCell>
                   <TableCell>
                     <Button variant="link" size="sm" asChild className="p-0 h-auto">
-                      <a href={api.documentationUrl} target="_blank" rel="noopener noreferrer">
+                      <a href={sanitizeUrl(api.documentationUrl)} target="_blank" rel="noopener noreferrer">
                         View Docs <ExternalLink className="ml-1 h-3 w-3" />
                       </a>
                     </Button>


### PR DESCRIPTION
Potential fix for [https://github.com/radhi1991/aran/security/code-scanning/1](https://github.com/radhi1991/aran/security/code-scanning/1)

To fix the issue, we need to validate and sanitize the `documentationUrl` before using it in the `<a>` tag. This can be achieved by:
1. Adding a utility function to validate URLs and ensure they conform to expected formats.
2. Using this function to sanitize the `newApiDocsUrl` value before adding it to the `apis` state.
3. Ensuring that only safe and valid URLs are used in the `href` attribute of the `<a>` tag.

The changes will be made in the following areas:
- Add a utility function for URL validation.
- Update the `handleAddApi` function to sanitize `newApiDocsUrl`.
- Ensure the sanitized value is used in the `<a>` tag.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
