### PR TITLE
docs: Add CONTRIBUTING.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT PROJECT OR MAINTAINER CONTACT EMAIL ADDRESS].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.md][v2.1].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.md
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to Aran API Sentinel
+
+First off, thank you for considering contributing to Aran API Sentinel! We welcome any contributions that can help make this project better, whether it's reporting a bug, proposing a new feature, or writing code.
+
+To ensure a smooth and effective collaboration, please review these guidelines.
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the [Aran API Sentinel Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to `[PROJECT_CONTACT_EMAIL_OR_LINK_TO_ISSUES]`.
+
+## How Can I Contribute?
+
+There are many ways to contribute to Aran API Sentinel:
+
+### Reporting Bugs
+*   If you encounter a bug, please ensure it hasn't already been reported by searching the [GitHub Issues](https://github.com/radhi1991/aran/issues) for this repository.
+*   If you don't see an open issue addressing the problem, please [open a new one](https://github.com/radhi1991/aran/issues/new). Be sure to include:
+    *   A clear and descriptive title.
+    *   A detailed description of the issue, including steps to reproduce it.
+    *   Information about your environment (e.g., browser version, Node.js version) if applicable.
+    *   Any relevant error messages or screenshots.
+
+### Suggesting Enhancements or New Features
+*   We welcome suggestions for enhancements or new features! Please start by checking if your idea has already been discussed in [GitHub Issues](https://github.com/radhi1991/aran/issues) or [GitHub Discussions](https://github.com/radhi1991/aran/discussions).
+*   If not, please [open a new issue](https://github.com/radhi1991/aran/issues/new) to propose your idea. Provide:
+    *   A clear and descriptive title.
+    *   A detailed explanation of the enhancement or feature.
+    *   The motivation or use case: why would this be useful?
+    *   Any potential drawbacks or alternative solutions you've considered.
+
+### Code Contributions
+
+#### Setting Up Your Development Environment
+1.  **Prerequisites**: Ensure you have Node.js (version specified in `package.json` `engines` field, e.g., >=18.0) and npm installed.
+2.  **Fork & Clone**: Fork the repository on GitHub, then clone your fork locally:
+    ```bash
+    git clone https://github.com/YOUR_USERNAME/aran.git
+    cd aran
+    ```
+3.  **Install Dependencies**:
+    *   For the main Next.js application and Genkit flows (from the project root):
+        ```bash
+        npm install
+        ```
+    *   For the Docusaurus documentation site:
+        ```bash
+        cd docs/website
+        npm install
+        cd ../..
+        ```
+4.  **Running the Application**: Refer to the main `README.md` for instructions on running the Next.js frontend, Genkit backend, and Docusaurus documentation site.
+
+#### Development Process
+*   **Branching**: Create a new branch for your feature or bugfix from an up-to-date `main` branch.
+    *   Use a descriptive branch name, e.g., `feature/awesome-new-feature` or `fix/bug-in-component`.
+    ```bash
+    git checkout main
+    git pull origin main
+    git checkout -b feature/your-descriptive-branch-name
+    ```
+*   **Coding Standards**:
+    *   Please follow the existing code style.
+    *   Ensure your code is well-formatted. Run the linter (if set up):
+        ```bash
+        npm run lint
+        ```
+*   **Commit Messages**: Write clear and concise commit messages. Consider using [Conventional Commits](https://www.conventionalcommits.org/) if you are familiar with them (e.g., `feat: Add X feature`, `fix: Resolve Y bug`).
+*   **Testing**:
+    *   We aim to maintain and increase test coverage. If you are adding new features, please try to include unit or integration tests. For bug fixes, a test demonstrating the fix is highly appreciated.
+    *   (Note: Specific testing commands or frameworks are not yet defined in the project, this is a general guideline).
+
+#### Submitting Pull Requests (PRs)
+1.  Push your changes to your fork:
+    ```bash
+    git push origin feature/your-descriptive-branch-name
+    ```
+2.  Open a Pull Request against the `main` branch of the `radhi1991/aran` repository.
+3.  **PR Description**:
+    *   Provide a clear title for your PR.
+    *   Describe the changes you have made and why.
+    *   If your PR addresses an open GitHub issue, link to it (e.g., "Closes #123").
+    *   Include any relevant information for reviewers, such as how to test your changes.
+4.  **Review Process**: Maintainers will review your PR. Be prepared to discuss your changes and make adjustments if requested. Once approved, your PR will be merged.
+
+## Questions?
+
+If you have questions about contributing, feel free to open an issue or reach out via other project communication channels (if specified).
+
+Thank you for contributing to Aran API Sentinel!


### PR DESCRIPTION
This commit introduces two important documents to guide your community engagement and contributions:

1.  **`CODE_OF_CONDUCT.md`**:
    *   Adds the Contributor Covenant version 2.1 as the official Code of Conduct for the project. This aims to foster an open and welcoming environment for all contributors and participants.

2.  **`CONTRIBUTING.md`**:
    *   Provides comprehensive guidelines for individuals wishing to contribute to the Aran API Sentinel project.
    *   Includes sections on:
        *   How to report bugs and suggest enhancements via GitHub Issues.
        *   Setting up the development environment (linking to README for details).
        *   The recommended development process (forking, branching, coding standards, commit messages, and testing).
        *   The process for submitting Pull Requests and what to expect during review.
        *   A link to the `CODE_OF_CONDUCT.md`.

These documents are essential for building a healthy and collaborative community around the project.